### PR TITLE
Add Login Basic Page

### DIFF
--- a/src/main/frontend/package.json
+++ b/src/main/frontend/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^7.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.3"
   },
   "scripts": {

--- a/src/main/frontend/src/App.js
+++ b/src/main/frontend/src/App.js
@@ -7,21 +7,6 @@ import Login from "./Login";
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
-
       <Router>
           <div id='switches'>
             <Switch>

--- a/src/main/frontend/src/App.js
+++ b/src/main/frontend/src/App.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import logo from './logo.svg';
 import './App.css';
+import {Route, Switch, BrowserRouter as Router} from 'react-router-dom';
+import Login from "./Login";
 
 function App() {
   return (
@@ -19,6 +21,14 @@ function App() {
           Learn React
         </a>
       </header>
+
+      <Router>
+          <div id='switches'>
+            <Switch>
+                <Route exact path="/" component={Login} />
+            </Switch>
+          </div>
+      </Router>
     </div>
   );
 }

--- a/src/main/frontend/src/App.test.js
+++ b/src/main/frontend/src/App.test.js
@@ -2,8 +2,4 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});
+

--- a/src/main/frontend/src/Login.Test.js
+++ b/src/main/frontend/src/Login.Test.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import App from './App';
+
+
+
+
+test()

--- a/src/main/frontend/src/Login.js
+++ b/src/main/frontend/src/Login.js
@@ -1,0 +1,13 @@
+import React, {Component} from 'react';
+
+
+
+export default class Login extends Component{
+    render() {
+        return(
+            <div>
+                <h2 style={{textAlign: "center"} }>Login Component Loaded! YAY!</h2>
+            </div>
+        )
+    }
+}


### PR DESCRIPTION
To verify it works:
- [ ] checkout the branch & "npm start" from "frontend" folder to launch the front end shite
- [ ] Scroll down, it should have a banner across the bottom saying, "Login Component Loaded. YAY!"

So, for whoever does the UI immediately following this task:
The login should be a page, all contained in the Login component (from a file titled the same). It will be the page the users first see on launching the game, and will be all in that file. There's a test file up, but you're going to rewrite whatever I put in there, so I didn't bother putting in any sanity tests, you'll just delete them anyways, and we aren't graded on test coverage. When creating the actual UI, feel free to get rid of both the banner I put up and Sai's placeholder atom thingy, I just left it up so you have that link too if you want it for now.