### PR TITLE
Update List of User Stories

### DIFF
--- a/1- User stories and tasks/P2_User_Stories.md
+++ b/1- User stories and tasks/P2_User_Stories.md
@@ -1,0 +1,69 @@
+Full List:
+(These may not be completely done in P2, but are at least worked on in part in P2)
+- Choose Opponent
+- Create Match
+- Login
+- Make Move
+- Play Concurrently
+- Registration
+- Turn Choice
+- View Matches
+- View My Profile
+- View Other Profiles
+- Win Or Lose
+
+Those Not In P2:
+(These exist as features to come, but are not being implemented in P2)
+- Board Display
+- Deregistration
+- Match Status
+- Quit Match
+
+
+
+Individual Descriptions:
+
+- Board Display:
+  As a user I would like to be able to view the board of a match I am in.
+
+- Choose Opponent:
+  As a user I would like to be able to choose whether to invite a specific opponent or send an open invitation.
+  
+- Create Match:
+  As a user I would like to be able to create a new match.
+
+- Deregistration:
+  As a user I would like to be able to deregister my own xgames account.
+
+- Login:
+  As a user I would like to be able to login to my own xgames account.
+
+- Make Move:
+  As a user I would like to be able to make a move in a match that I am playing.
+
+- Match Status:
+  As a user I would like to be able to view the status of all matches I am in.
+
+- Play Concurrently:
+  As a user I would like to be able to put this match down and come back to it again later.
+
+- Quit Match:
+  As a user I would like to be able to quit (conceding) a match that I am in.
+
+- Registration:
+  As a user I would like to be able to register my own unique account.
+
+- Turn Choice:
+  As a user I would like to be able to choose who the first to play is somehow.
+
+- View Matches:
+  As a user I would like to be able to view all of my match inviations.
+
+- View My Own Profile:
+  As a user I would like to be able to view my own profile and history.
+
+- View Others' Profiles:
+  As a user I would like to be able to view others' profiles and match histories.
+
+- Win or Lose:
+  As a user I would like to be able to win or lose a match that I am playing.


### PR DESCRIPTION
Just adds in a list of all the user stories we are and are not doing this go around, which should make the reports at the end of this easier. Updated to match with zenhub in titles.