### PR TITLE
[Fixes #51] Complete Ongoing Matches Edge Cases

### DIFF
--- a/src/main/frontend/src/Lobby/Ongoing Matches/OngoingMatches.js
+++ b/src/main/frontend/src/Lobby/Ongoing Matches/OngoingMatches.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Table } from 'reactstrap';
+import { Button, Table } from 'reactstrap';
 
 export default class OngoingMatches extends Component {
     constructor(props) {
@@ -7,12 +7,15 @@ export default class OngoingMatches extends Component {
         this.state = {
             userID: this.props.location.state.userID,
             password: this.props.location.state.password,
+            loginFailed: false,
             matches: [],
         }
+        this.onSubmit = this.onSubmit.bind(this);
+        this.populateMatches = this.populateMatches.bind(this);
     }
 
     componentDidMount() {
-        fetch("/matches?userID=" + this.state.userID)
+        fetch("/matches?userID=" + this.state.userID + "&password=" + this.state.password)
             .then(res => res.json())
             .then(result => {
                 this.setState({ matches: result.matches })
@@ -20,39 +23,64 @@ export default class OngoingMatches extends Component {
     }
 
     populateMatches() {
-        if (this.state.matches.length !== 0) {
+        if (this.state.matches.length < 1) {
+            return (
+                <>
+                    You have no ongoing matches to display.
+                </>
+            )
+        } else {
             let allMatches = this.state.matches.map(match =>
-                    <tr key={match}>
-                        <td> {match[0]} </td>
-                        <td>Go to match</td> 
-                        <td> {match[1]} </td>
-                        <td> {match[2]} </td>
-                    </tr>
+                <tr key={match}>
+                    <td>
+                    <Button color="link">{match[0]}</Button>
+                    </td>
+                    <td> {match[1]} </td>
+                    <td> {match[2]} </td>
+                </tr>
             )
             return (
                 <>
-                    { allMatches }
+                    <thead>
+                        <tr>
+                            <th>Match ID</th>
+                            <th>Opponent</th>
+                            <th>Next Move</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        { allMatches } 
+                    </tbody>
                 </>
             )
         }
+    }
+
+    onSubmit() {
+        fetch("/login?userID=" + this.state.userID + "&password=" + this.state.password)
+            .then(res => res.json())
+            .then(result => {
+                if (result.loginSuccess) {
+                    this.props.history.push({
+                        pathname: "/lobby",
+                        state: {
+                            userID: this.state.userID,
+                            password: this.state.password,
+                        }
+                    });
+                } else {
+                    this.setState({ loginFailed: true })
+                }
+            })
     }
 
     render() {
         return (
             <div>
                 <h2 style={{ textAlign: "center" }}>Ongoing Matches</h2>
+                <Button onClick={ this.onSubmit } type='button'>Return to Lobby</Button>
                 <Table>
-                    <thead>
-                        <tr>
-                            <th>Match ID</th>
-                            <th>Link</th>
-                            <th>Opponent</th>
-                            <th>Next Move</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        { this.populateMatches() } 
-                    </tbody>
+                    { this.populateMatches() }
                 </Table>
             </div>
         )

--- a/src/main/java/cs414f20/teamd/Login/Login.java
+++ b/src/main/java/cs414f20/teamd/Login/Login.java
@@ -7,7 +7,6 @@ public class Login {
     private String password;
     private java.time.LocalDate date;
     boolean loginSuccess;
-    String dbResults;
 
     public Login() {
     }
@@ -42,7 +41,6 @@ public class Login {
             ", password='" + getPassword() + "'" +
             ", date='" + getDate() + "'" +
             ", successfully logged in='" + getLoginSuccess() + "'" +
-            ", database results='" + dbResults + "'" +
             "}";
     }
 

--- a/src/main/java/cs414f20/teamd/OngoingMatches/OngoingMatches.java
+++ b/src/main/java/cs414f20/teamd/OngoingMatches/OngoingMatches.java
@@ -2,29 +2,42 @@ package cs414f20.teamd.OngoingMatches;
 
 import cs414f20.teamd.DatabaseConnection.Database;
 
+import java.util.ArrayList;
 import java.util.List;
+
+// import javax.xml.crypto.Data;
 
 public class OngoingMatches {
     private String userID;
+    private String password;
     private List<List<String>> matches;
 
-    public OngoingMatches() {
+    public OngoingMatches() { 
     }
 
-    public OngoingMatches(String userID) {
+    public OngoingMatches(String userID, String password) {
         this.userID = userID;
+        this.password = password;
     }
 
     public String getUserID() {
         return this.userID;
     }
 
+    public String getPassword() {
+        return this.password;
+    }
+
     public boolean hasMatches() {
-        return this.matches != null;
+        return !this.matches.isEmpty();
     }
 
     public List<List<String>> getMatches() {
         return this.matches;
+    }
+
+    public boolean attemptLogin() {
+        return Database.tryLogin(this.userID, this.password);
     }
 
     @Override
@@ -32,14 +45,24 @@ public class OngoingMatches {
         return "{" +
             "========== TEST: Ongoing Matches Object Sent to Controller==========\n" +
             " userID='" + getUserID() + "'" +
+            " password='" + getPassword() + "'" +
+            " logged in ='" + attemptLogin() + "'" +
             ", has ongoing matches='" + hasMatches() + "'" +
             ", match list='" + getMatches() + "'" +
             "}";
     }
 
     public void queryDatabase() {
-        this.matches = Database.getOngoingMatches(userID);
-    } 
+        if (attemptLogin()) {
+            this.matches = Database.getOngoingMatches(this.userID);
+            // if (this.matches.isEmpty()) {
+            //     List<String> emptyMatch = new ArrayList<>();
+            //     emptyMatch.add("None");
+            //     emptyMatch.add("");
+            //     emptyMatch.add("");
+            //     this.matches.add(emptyMatch);
+            // }
+        }
+    }
 
-    
 }

--- a/src/main/java/cs414f20/teamd/OngoingMatches/OngoingMatchesController.java
+++ b/src/main/java/cs414f20/teamd/OngoingMatches/OngoingMatchesController.java
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class OngoingMatchesController {
     
     @GetMapping("/matches")
-    public OngoingMatches matches(@RequestParam String userID) {
-        OngoingMatches currentMatches = new OngoingMatches(userID);
+    public OngoingMatches matches(@RequestParam String userID, String password) {
+        OngoingMatches currentMatches = new OngoingMatches(userID, password);
         currentMatches.queryDatabase();
         System.out.println(currentMatches);
         return currentMatches;

--- a/src/test/java/cs414f20/teamd/OngoingMatchesTest.java
+++ b/src/test/java/cs414f20/teamd/OngoingMatchesTest.java
@@ -8,7 +8,7 @@ import cs414f20.teamd.OngoingMatches.OngoingMatches;
 class OngoingMatchesTest {
     @Test
     void testMatches() {
-        OngoingMatches test = new OngoingMatches("Nick");
+        OngoingMatches test = new OngoingMatches("Nick", "42");
         assertEquals("Nick", test.getUserID());
         test.queryDatabase();
         assertNotNull(test.getMatches());


### PR DESCRIPTION
- [x] Add message to show when a user has no ongoing matches to display
- [x] Create framework for linking to ongoing matches
- [x] Create link back to lobby
- [x] Remove ability for a user to access page without being logged in

- If a malicious user attempts to access the URL directly, they will receive an error since the username they provide will not be passed through the history and therefore will not be set in props/state